### PR TITLE
slicing [1/x] Support basic slicing of sequences

### DIFF
--- a/codemod_yaml/box/py/sequence.py
+++ b/codemod_yaml/box/py/sequence.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from ..style import YamlStyle
 
-from . import BoxedPy, boxpy
+from . import BoxedPy, boxpy, register
 
 __all__ = [
     "PyBlockSequence",
@@ -12,14 +12,13 @@ __all__ = [
 ]
 
 
+@register(list)
 class PyBlockSequence(BoxedPy):
-    register_py_type = list
-
     _items: list[PyBlockSequenceItem]
 
     def __post_init__(self) -> None:
         self._items = []
-        for child in self.value.children:
+        for child in self.value:
             self._items.append(PyBlockSequenceItem(boxpy(child)))
 
     def to_bytes(self) -> bytes:

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,5 +80,5 @@ depends =
     py{37,38,39,310,311,312}
 
 [flake8]
-ignore = E203, E231, E266, E302, E501, W503
+ignore = E203, E231, E266, E302, E501, W503, E301, E704
 max-line-length = 88

--- a/tests/test_box_yaml_sequence.py
+++ b/tests/test_box_yaml_sequence.py
@@ -73,3 +73,32 @@ def test_nested_sequence():
     assert stream.text == b"-\n  -  a\n  -  c\n"
     stream[0].append(PyScalarString("d", QuoteStyle.BARE))
     assert stream.text == b"-\n  -  a\n  -  c\n  -  d\n"
+
+def test_slicing():
+    stream = parse_str("""\
+-
+  -  a
+  -  b
+  -  c
+  -  d
+""")
+    assert stream[0][0:2] == ["a", "b"]
+    assert stream[0][1:3] == ["b", "c"]
+    assert stream[0][1:] == ["b", "c", "d"]
+    assert stream[0][:2] == ["a", "b"]
+    assert stream[0][0:3:2] == ["a", "c"]
+    assert stream[0][1:3:2] == ["b"]
+    assert stream[0][1::2] == ["b", "d"]
+    assert stream[0][1:3:1] == ["b", "c"]
+
+def test_slicing_modification():
+    stream = parse_str("""\
+-
+    -   a
+""")
+    stream[0][:] = [PyScalarString("b", QuoteStyle.BARE), PyScalarString("c", QuoteStyle.BARE)]
+    assert stream.text == b"""\
+-
+    -   b
+    -   c
+"""


### PR DESCRIPTION
Doesn't yet support the case of x[:0] = [1, 2, 3] (which is a different length), which I hope is uncommon.  My main use of this is [:] which works here.