### PR TITLE
Adjust sequence end position conditionally

### DIFF
--- a/codemod_yaml/box/yaml/sequence.py
+++ b/codemod_yaml/box/yaml/sequence.py
@@ -98,6 +98,13 @@ class YamlBlockSequence(BoxedYaml, UserList):
             assert isinstance(node, YamlBlockSequenceItem)
             self._items[index] = node
 
+    @property
+    def end_byte(self) -> int:
+        if self.node.text[-1:] == b"\n":
+            return self.node.end_byte
+        else:
+            return self.node.end_byte + 1
+
 
 @register("block_sequence_item")
 class YamlBlockSequenceItem(BoxedYaml):
@@ -124,14 +131,25 @@ class YamlBlockSequenceItem(BoxedYaml):
             self.node.start_byte - expected_indent : self.node.start_byte
         ]
         assert (
+            self.stream._original_bytes[
+                self.node.start_byte
+                - expected_indent
+                - 1 : self.node.start_byte
+                - expected_indent
+            ]
+            == b"\n"
+        )
+        assert (
             leading_whitespace == b" " * expected_indent
         )  # can't handle same-line block like "- - a" yet
         return self.node.start_byte - expected_indent
 
     @property
     def end_byte(self) -> int:
-        # TODO conditional
-        return self.node.end_byte + 1
+        if self.node.text[-1:] == b"\n":
+            return self.node.end_byte
+        else:
+            return self.node.end_byte + 1
 
     @property
     def yaml_style(self) -> YamlStyle:

--- a/codemod_yaml/box/yaml/sequence.py
+++ b/codemod_yaml/box/yaml/sequence.py
@@ -100,7 +100,9 @@ class YamlBlockSequence(BoxedYaml, UserList):
 
     @property
     def end_byte(self) -> int:
-        if self.node.text[-1:] == b"\n":
+        text = self.node.text
+        assert isinstance(text, bytes)
+        if text[-1:] == b"\n":
             return self.node.end_byte
         else:
             return self.node.end_byte + 1
@@ -146,7 +148,9 @@ class YamlBlockSequenceItem(BoxedYaml):
 
     @property
     def end_byte(self) -> int:
-        if self.node.text[-1:] == b"\n":
+        text = self.node.text
+        assert isinstance(text, bytes)
+        if text[-1:] == b"\n":
             return self.node.end_byte
         else:
             return self.node.end_byte + 1

--- a/tests/test_box_yaml_sequence.py
+++ b/tests/test_box_yaml_sequence.py
@@ -103,6 +103,26 @@ def test_slicing_modification():
     -   c
 """
 
+def test_combo_modification():
+    stream = parse_str("""\
+a:
+ - 1
+ - 2
+
+b:
+""")
+    # tree-sitter appears to give the sequence all the trailing newlines UNLESS
+    # followed by a map key, in which case nobody gets them.
+    stream["a"][:] = [3, 4, 5]
+    assert stream.text == b"""\
+a:
+ - 3
+ - 4
+ - 5
+
+b:
+"""
+
 def test_cookie_sequence():
     stream = parse_str("""\
 - a


### PR DESCRIPTION
Looks like the trailing newline is _not_ included if a map key follows the sequence, otherwise it includes any such newlines.  With test.

Observed making edits on real-world files.