### PR TITLE
Simplify edit() by removing the `append` option.

### DIFF
--- a/codemod_yaml/base.py
+++ b/codemod_yaml/base.py
@@ -19,7 +19,7 @@ class YamlStream(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def edit(self, item: Item, new_item: Optional[Item], append: bool = False) -> int:
+    def edit(self, item: Item, new_item: Optional[Item]) -> int:
         pass
 
     # Forwarding methods


### PR DESCRIPTION
This was always somewhat problematic, given that it takes a zero-width original span, which could occur at the end point of multiple items.

Given the single-item sequence

```
- a
```

doing an `s.append("b")` and `del s[0]` should not remove the `b` edit, but doing `s.anneal()` should.  Now that broad compatibility is better, the `items.py` code does not use `append=True` anymore and we don't need this path.