### PR TITLE
Implement support for multiple documents

### DIFF
--- a/tests/multi_doc.yaml
+++ b/tests/multi_doc.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploy-nginx
+spec:
+  replicas: {{ replicas }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-state-gatherer
+spec:
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: deploy-nginx
+spec:
+  ports:
+  - name: deploy-manager
+    port: 8081
+  selector:
+    service.openai.com/name: deploy-manager

--- a/tests/test_multi_doc.py
+++ b/tests/test_multi_doc.py
@@ -1,0 +1,50 @@
+"""
+A single yaml file with multiple documents.
+"""
+
+from pathlib import Path
+from codemod_yaml import parse_str
+import moreorless
+
+MULTI_DOC_PATH = Path(__file__).parent / "multi_doc.yaml"
+MULTI_DOC_TEXT = MULTI_DOC_PATH.read_text()
+
+
+def test_value_replacement_doc_0():
+    stream = parse_str(MULTI_DOC_TEXT)
+    assert stream[0]["kind"] == "Deployment"
+    stream[0]["kind"] = "CronJob"
+    output = moreorless.unified_diff(
+        MULTI_DOC_TEXT, stream.text.decode("utf-8"), filename="multi_doc.yaml", n=0
+    )
+
+    assert (
+        output
+        == """\
+--- a/multi_doc.yaml
++++ b/multi_doc.yaml
+@@ -2 +2 @@
+-kind: Deployment
++kind: "CronJob"
+"""
+    )
+
+
+def test_value_replacement_doc_1():
+    stream = parse_str(MULTI_DOC_TEXT)
+    assert stream[1]["metadata"]["name"] == "nginx-state-gatherer"
+    stream[1]["metadata"]["name"] = "apache-state-gatherer"
+    output = moreorless.unified_diff(
+        MULTI_DOC_TEXT, stream.text.decode("utf-8"), filename="multi_doc.yaml", n=0
+    )
+
+    assert (
+        output
+        == """\
+--- a/multi_doc.yaml
++++ b/multi_doc.yaml
+@@ -11 +11 @@
+-  name: nginx-state-gatherer
++  name: "apache-state-gatherer"
+"""
+    )

--- a/tests/test_multi_doc.py
+++ b/tests/test_multi_doc.py
@@ -12,8 +12,8 @@ MULTI_DOC_TEXT = MULTI_DOC_PATH.read_text()
 
 def test_value_replacement_doc_0():
     stream = parse_str(MULTI_DOC_TEXT)
-    assert stream[0]["kind"] == "Deployment"
-    stream[0]["kind"] = "CronJob"
+    assert stream.documents[0]["kind"] == "Deployment"
+    stream.documents[0]["kind"] = "CronJob"
     output = moreorless.unified_diff(
         MULTI_DOC_TEXT, stream.text.decode("utf-8"), filename="multi_doc.yaml", n=0
     )
@@ -32,8 +32,8 @@ def test_value_replacement_doc_0():
 
 def test_value_replacement_doc_1():
     stream = parse_str(MULTI_DOC_TEXT)
-    assert stream[1]["metadata"]["name"] == "nginx-state-gatherer"
-    stream[1]["metadata"]["name"] = "apache-state-gatherer"
+    assert stream.documents[1]["metadata"]["name"] == "nginx-state-gatherer"
+    stream.documents[1]["metadata"]["name"] = "apache-state-gatherer"
     output = moreorless.unified_diff(
         MULTI_DOC_TEXT, stream.text.decode("utf-8"), filename="multi_doc.yaml", n=0
     )


### PR DESCRIPTION
Using `.documents[0]` is probably the way future docs will tell you to access the "root" -- that avoids having so many (yet still incomplete) forwarding methods on stream, and more closely matches how the yaml grammar is actually structured.